### PR TITLE
Implement individual Component support

### DIFF
--- a/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psd1
+++ b/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psd1
@@ -112,7 +112,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        # Prerelease = ''
+        Prerelease = 'beta'
 
         # Flag to indicate whether the module requires explicit user acceptance for install/update/save
         # RequireLicenseAcceptance = $false

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ The `AddVSComponents` resource is used to modify a pre-existing Visual Studio in
 
 ### Parameters
 
+At least `VSConfigFile` or `Components` must be specified. You can also specify both simultaneously.
+
 **Parameter**|**Attribute**|**DataType**|**Description**|**Allowed Values**
 :-----|:-----|:-----|:-----|:-----
 `ProductId`|Key|String|The product identifier of the instance you are working with. EG: `Microsoft.VisualStudio.Product.Community`|See [workload and component ids](https://learn.microsoft.com/en-us/visualstudio/install/workload-and-component-ids)
 `ChannelId`|Key|String|The channel identifier of the instance you are working with. EG: `VisualStudio.17.Release`|See [channel identifiers](https://learn.microsoft.com/en-us/visualstudio/install/command-line-parameter-examples#using---channelId)
-`VSConfigFile`|Mandatory|String|Path to the Installation Configuration (VSConfig) file you wish to update the provided instance with.|Valid file path to a .vsconfig file
+`Components`|Optional|StringArray[]|Collection of component identifiers you wish to update the provided instance with.|See [workload and component ids](https://learn.microsoft.com/en-us/visualstudio/install/workload-and-component-ids)
+`VSConfigFile`|Optional|String|Path to the [Installation Configuration (VSConfig) file](https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/) you wish to update the provided instance with.|Valid file path to a .vsconfig file
+`IncludeRecommended`|Optional|Boolean|For the provided required components, also add recommended components into the specified instance|True/False
+`IncludeOptional`|Optional|Boolean|For the provided required components, also add optional components into the specified instance|True/False
 `InstalledComponents`|NotConfigurable|StringArray[]|A collection of components installed in the Visual Studio instance identified by the provided Product ID and Channel ID.|N/A
 
 


### PR DESCRIPTION
Implemented support for specific additions of components and workloads to the `AddVSComponents` resource, along with support for the recommended and optional flags.

This blended implementation will provide both VSConfig and specified components cumulatively, and will require either a file or component list to be passed.