### PR TITLE
Ignore white space in vsconfig path and check if vsconfig exists or not for Test()

### DIFF
--- a/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
+++ b/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
@@ -55,8 +55,13 @@ class VSComponents
         $this.Get()
         $requestedComponents = $this.components
 
-        if($this.vsConfigFile)
+        if ($this.vsConfigFile)
         {
+            if(-not (Test-Path $this.vsConfigFile))
+            {
+                throw "Provided Installation Configuration file does not exist at $($this.vsConfigFile)"
+            }
+
             $requestedComponents += Get-Content $this.vsConfigFile | Out-String | ConvertFrom-Json | Select-Object -ExpandProperty components
         }
 
@@ -184,7 +189,7 @@ function Add-VsComponents
             throw "Provided Installation Configuration file does not exist at $VsConfigPath"
         }
 
-        $installerArgs += " --config $VsConfigPath"
+        $installerArgs += " --config `"$VsConfigPath`""
     }
 
     if($Components)


### PR DESCRIPTION
## What
Ignore white space in vsconfig path and check if vsconfig exists or not for Test method

## Why
Previously, the vsconfig was ignored is there was whitespace in the path. It should be recognized as it's a valid location, hence fixed logic to escape white spaces. Additionally added a logic to check if the vsconfig exists or not in test method

## How
Escape white spaces and add if check to test the vsconfig file path.

Manual test

**Component from vsconfig was added when path to the vsconfig had space in it**
![existing_vsconfig_space_in_path](https://github.com/microsoft/VisualStudioDSC/assets/38011929/5cd9d20d-c4e8-459b-ac90-9f1c4ac2be82)

**Successfully recognizing vsconfig doesn't exist**
![vsconfig_does_not_exist](https://github.com/microsoft/VisualStudioDSC/assets/38011929/0b166177-2fae-4657-b7cd-2b204286bdf2)
