### PR TITLE
Enable installer update if available and the installer is aware of it

### DIFF
--- a/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
+++ b/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
@@ -175,7 +175,7 @@ function Add-VsComponents
         [bool]$IncludeOptional
     )
     
-    $installerArgs = "modify --productId $ProductId --channelId $ChannelId --quiet --norestart --noupdateinstaller"
+    $installerArgs = "modify --productId $ProductId --channelId $ChannelId --quiet --norestart"
 
     if(-not $Components -and -not $VsConfigPath)
     {
@@ -240,6 +240,7 @@ function Invoke-VsInstaller
 
     $installer = Start-Process -FilePath (Get-VsInstallerPath) -ArgumentList $Arguments -PassThru
     $installer.WaitForExit();
+    Wait-Process -name setup;
 
     # See script block description for error code explanation
     $validErrorCodes = 0,3010,862968;

--- a/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
+++ b/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
@@ -55,7 +55,7 @@ class VSComponents
         $this.Get()
         $requestedComponents = $this.components
 
-        if ($this.vsConfigFile)
+        if($this.vsConfigFile)
         {
             if(-not (Test-Path $this.vsConfigFile))
             {
@@ -67,7 +67,7 @@ class VSComponents
 
         foreach ($component in $requestedComponents)
         {
-            if ($this.installedComponents -notcontains $component)
+            if($this.installedComponents -notcontains $component)
             {
                 return $false
             }
@@ -213,6 +213,35 @@ function Add-VsComponents
 
 <#
 .SYNOPSIS
+    Builds a base path, if it exists, with the provided argument.
+
+.DESCRIPTION
+    Builds a base path with the provided argument.
+    This is used to build a base path for process ids of setup.exe or vswhere.exe.
+
+.PARAMETER Arguments
+    Arguments to build a base path with
+#>
+function Build-BasePath
+{
+    param
+    (
+        [Parameter()]
+        [string]$ExePath
+    )
+
+    $basePath = Join-Path -Path "${env:ProgramFiles(x86)}" -ChildPath "Microsoft Visual Studio"
+
+    if($ExePath)
+    {
+        return Join-Path -Path $basePath -ChildPath $ExePath
+    }
+
+    return $basePath
+}
+
+<#
+.SYNOPSIS
     Invokes Visual Studio Installer, if it exists, with the provided arguments.
 
 .DESCRIPTION
@@ -240,8 +269,13 @@ function Invoke-VsInstaller
 
     $installer = Start-Process -FilePath (Get-VsInstallerPath) -ArgumentList $Arguments -PassThru
     $installer.WaitForExit();
-    # Wait for all processes in case there is an installer update
-    Wait-Process -name setup;
+    $basePath = Build-BasePath
+    $activeInstallerProcessIds = Get-Process Setup | Where-Object { $_.Path -like "$basePath*" } | Select-Object -ExpandProperty Id
+
+    if($activeInstallerProcessIds)
+    {
+        Wait-Process -Id $activeInstallerProcessIds -Timeout 3600
+    }
 
     # See script block description for error code explanation
     $validErrorCodes = 0,3010,862968;
@@ -284,7 +318,7 @@ function Invoke-VsWhere
 #>
 function Assert-IsAdministrator
 {
-    if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
+    if(-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
     {
         throw "This resource must be run as an Administrator."
     }
@@ -296,7 +330,7 @@ function Assert-IsAdministrator
 #>
 function Get-VsInstallerPath
 {
-    return Join-Path -Path "${env:ProgramFiles(x86)}" -ChildPath "Microsoft Visual Studio\Installer\setup.exe"
+    return Build-BasePath -ExePath "Installer\setup.exe"
 }
 
 <#
@@ -305,7 +339,7 @@ function Get-VsInstallerPath
 #>
 function Get-VsWherePath
 {
-    return Join-Path -Path "${env:ProgramFiles(x86)}" -ChildPath "Microsoft Visual Studio\Installer\vswhere.exe"
+    return Build-BasePath -ExePath "Installer\vswhere.exe"
 }
 
 <#
@@ -338,7 +372,7 @@ function Assert-VsWherePresent
 #>
 function Assert-VsInstallerProcessNotRunning
 {
-    if (Get-Process | Where-Object { $_.Path -eq (Get-VsInstallerPath) })
+    if(Get-Process | Where-Object { $_.Path -eq (Get-VsInstallerPath) })
     {
         throw "Visual Studio Installer is running. Close the installer and try again."
     }

--- a/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
+++ b/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
@@ -240,6 +240,7 @@ function Invoke-VsInstaller
 
     $installer = Start-Process -FilePath (Get-VsInstallerPath) -ArgumentList $Arguments -PassThru
     $installer.WaitForExit();
+    # Wait for all processes in case there is an installer update
     Wait-Process -name setup;
 
     # See script block description for error code explanation


### PR DESCRIPTION
### What
Enable the installer update if it's available and the installer is aware of it

### Why
The installer update process will close once the installer update completes. We should wait for the child processes to complete install/modify 

### How
Wait for the processes with name setup to complete to ensure we are waiting for all of the processes

### Test
Manually put the installer in a state where there is an update and used vsconfig to modify (CLR data types for SQL server component)

1. Open installer to make it be aware of installer update and make sure components get added. The installer version updated components were added.

<img width="193" alt="image" src="https://github.com/microsoft/VisualStudioDSC/assets/38011929/7ee9c483-28b1-44dd-80d0-2ba0ed959b99">

<img width="177" alt="image" src="https://github.com/microsoft/VisualStudioDSC/assets/38011929/ef1fdfd6-e701-4b1d-a26e-0c980022dfb5">

<img width="177" alt="image" src="https://github.com/microsoft/VisualStudioDSC/assets/38011929/599d24c9-8f0c-417e-947f-d0d75e18afb9">


2. Don't open installer so that it's not aware of installer update and make sure components get added
Installer version didn't update and stayed
<img width="170" alt="image" src="https://github.com/microsoft/VisualStudioDSC/assets/38011929/8e127366-4c21-4316-a1d6-ef64085b1fe1">
<img width="177" alt="image" src="https://github.com/microsoft/VisualStudioDSC/assets/38011929/62723486-e7ee-4f85-8bce-bb975d5d7e1d">
