### PR TITLE
Add support for --allowUnsignedExtensions

### DIFF
--- a/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
+++ b/Microsoft.VisualStudio.DSC/Microsoft.VisualStudio.DSC.psm1
@@ -27,6 +27,9 @@ class VSComponents
     [DscProperty()]
     [bool]$includeOptional = $false
 
+    [DscProperty()]
+    [bool]$allowUnsignedExtensions = $false
+
     [DscProperty(NotConfigurable)]
     [string[]]$installedComponents
 
@@ -41,6 +44,7 @@ class VSComponents
             vsConfigFile = $this.vsConfigFile
             includeRecommended = $this.includeRecommended
             includeOptional = $this.includeOptional
+            allowUnsignedExtensions = $this.allowUnsignedExtensions
             installedComponents = $this.installedComponents
         }
     }
@@ -83,7 +87,7 @@ class VSComponents
             return
         }
 
-        Add-VsComponents -ProductId $this.productId -ChannelId $this.channelId -VsConfigPath $this.vsConfigFile -Components $this.components -IncludeRecommended $this.includeRecommended -IncludeOptional $this.includeOptional
+        Add-VsComponents -ProductId $this.productId -ChannelId $this.channelId -VsConfigPath $this.vsConfigFile -Components $this.components -IncludeRecommended $this.includeRecommended -IncludeOptional $this.includeOptional -AllowUnsignedExtensions $this.allowUnsignedExtensions
     }
 }
 
@@ -140,6 +144,9 @@ function Get-VsComponents
 .PARAMETER IncludeOptional
     For the provided required components, also add optional components into the specified instance
 
+.PARAMETER AllowUnsignedExtensions
+    For the provided extensions, allow unsigned extensions to be installed into the specified instance
+    
 .LINK
     https://learn.microsoft.com/en-us/visualstudio/install/workload-and-component-ids
 
@@ -173,6 +180,9 @@ function Add-VsComponents
         
         [Parameter()]
         [bool]$IncludeOptional
+        
+        [Parameter()]
+        [bool]$AllowUnsignedExtensions
     )
     
     $installerArgs = "modify --productId $ProductId --channelId $ChannelId --quiet --norestart"
@@ -206,6 +216,11 @@ function Add-VsComponents
     if($IncludeOptional)
     {
         $installerArgs += " --includeOptional"
+    }
+
+    if($AllowUnsignedExtensions)
+    {
+        $installerArgs += " --allowUnsignedExtensions"
     }
 
     Invoke-VsInstaller -Arguments $installerArgs

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ At least `VSConfigFile` or `Components` must be specified. You can also specify 
 `VSConfigFile`|Optional|String|Path to the [Installation Configuration (VSConfig) file](https://learn.microsoft.com/visualstudio/install/import-export-installation-configurations) you wish to update the provided instance with.|Valid file path to a .vsconfig file
 `IncludeRecommended`|Optional|Boolean|For the provided required components, also add recommended components into the specified instance|True/False
 `IncludeOptional`|Optional|Boolean|For the provided required components, also add optional components into the specified instance|True/False
+`AllowUnsignedExtensions`|Optional|Boolean|For the provided extensions, allow installing unsigned extensions into the specified instance|True/False
 `InstalledComponents`|NotConfigurable|StringArray[]|A collection of components installed in the Visual Studio instance identified by the provided Product ID and Channel ID.|N/A
 
 


### PR DESCRIPTION

## What?
Add support for `--allowUnsignedExtensions`

## Why?
We need to add support for `--allowUnsignedExtensions` in order to let DSC provider install unsigned extensions by passing the right parameter to the installer.

## How?
Add command line parameter support, just like `includeRecommended` and `includeOptional`. Default is `false`.