### PR TITLE
Convert build pipeline to MicroBuild template

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -4,6 +4,19 @@ stages:
     - job: 'Build'
       displayName: 'Build & Sign DSC Module'
       pool: '$(MicroBuildPool)'
+      templateContext:
+        mb:
+          signing:
+            enabled: true
+            signType: $(SignType)
+            zipSources: false
+
+        outputs:
+          - output: pipelineArtifact
+            targetPath: '$(Build.ArtifactStagingDirectory)\dropModule'
+            displayName: 'Publish module artifact'
+            artifactName: dropModule
+
       steps:
         - checkout: self
           fetchDepth: 0
@@ -35,13 +48,6 @@ stages:
              ForEach-Object {$_ -Replace 'CmdletsTo', '#CmdletsTo' -Replace 'AliasesTo', '#AliasesTo' } | `
              Set-Content -Path $updateModuleParams.Path
           displayName: 'Update Module Version'
-
-        - task: MicroBuildSigningPlugin@4
-          inputs:
-            signType: '$(SignType)'
-            feedSource: 'https://pkgs.dev.azure.com/devdiv/_packaging/MicroBuildToolset/nuget/v3/index.json'
-          env:
-            TeamName: '$(TeamName)'
 
         - pwsh: |
             $catalogFiles = Get-ChildItem $(ModuleSourceFolder) -Recurse -File
@@ -79,10 +85,6 @@ stages:
           inputs:
             contents: $(ModuleSourceFolder)\**
             targetFolder: '$(Build.ArtifactStagingDirectory)\dropModule'
-
-        - publish: '$(Build.ArtifactStagingDirectory)\dropModule'
-          displayName: 'Publish module artifact'
-          artifact: dropModule
 
         - task: MicroBuildCleanup@1
           env:

--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -15,6 +15,25 @@ pr: none
 variables:
   - template: 'variables.yml'
 
-stages:
-  - template: 'build.yml'
-  - template: 'publish.yml'
+resources:
+  repositories:
+    - repository: MicroBuildTemplate
+      type: git
+      name: 1ESPipelineTemplates/MicroBuildTemplate
+      ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    sdl:
+      policheck:
+        enabled: true
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true
+
+    stages:
+      - template: 'build.yml'
+      - template: 'publish.yml'


### PR DESCRIPTION
Our compliance standards now require our production pipelines to use the 1ES template. The MicroBuild template is an extension of that required template and allows for easily enabling signing. 

This change converts to that template and enables signing through the template.