### PR TITLE
Enable PME signing and only allow for real-signed production builds

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -10,6 +10,8 @@ stages:
             enabled: true
             signType: $(SignType)
             zipSources: false
+            ${{ if eq(variables['SignType'], 'real') }}:
+              signWithProd: true
 
         outputs:
           - output: pipelineArtifact

--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -19,10 +19,7 @@ variables:
     value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 
   - name: 'SignType'
-    ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-      value: 'real'
-    ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-      value: 'test'
+    value: 'real' # Always needs to real sign for CI pipeline, refactoring needed for PRs: https://task.ms/dd/2507602
 
 parameters:
   - name: LogBugs


### PR DESCRIPTION
## What/Why
We need to enable PME signing with the new rule enforcement (Real signing with PME Enforcement - June 30th 2025). Furthermore, the new rule states that the non-production and production pipelines should be separate.

## How
Enable PME signing with `signWithProd: true` and only allow real-signed builds on the CI production pipeline. Talked to @Ryan about a backlog item: https://task.ms/dd/2507602

## Testing
Verified the stages can be configured in the topic branch (which indicates no errors in the pipeline).

![image](https://github.com/user-attachments/assets/a139e928-2860-472e-8f4b-e385882f7b91)
