### PR TITLE
Add artifact input to templateContext

### DIFF
--- a/build/publish.yml
+++ b/build/publish.yml
@@ -8,6 +8,10 @@ stages:
       templateContext:
         type: releaseJob 
         isProduction: true
+        inputs:
+          - input: pipelineArtifact
+            artifactName: dropModule
+            targetPath: $(Pipeline.Workspace)/dropModule
     
       pool: '$(MicroBuildPool)'
 
@@ -16,9 +20,6 @@ stages:
 
       steps:
       - checkout: none  
-
-      - download: current
-        artifact: dropModule
 
       - pwsh: |
           $isPreRelease = -not [string]::IsNullOrEmpty((Test-ModuleManifest -Path $(Pipeline.Workspace)\dropModule\Microsoft.VisualStudio.DSC\Microsoft.VisualStudio.DSC.psd1).PrivateData.PSData.Prerelease)


### PR DESCRIPTION
The 1ES Pipeline Templates do not allow the '- download:' step shorthand in release jobs. Use the pipelineArtifact input in templateContext instead. 