### PR TITLE
Make the Gallery publish step re-runnable and pin PSResourceGet

### DIFF
--- a/build/publish.yml
+++ b/build/publish.yml
@@ -22,27 +22,73 @@ stages:
       - checkout: none  
 
       - pwsh: |
-          $isPreRelease = -not [string]::IsNullOrEmpty((Test-ModuleManifest -Path $(Pipeline.Workspace)\dropModule\Microsoft.VisualStudio.DSC\Microsoft.VisualStudio.DSC.psd1).PrivateData.PSData.Prerelease)
+          $ErrorActionPreference = 'Stop'
+
+          $manifest = Test-ModuleManifest -Path "$(Pipeline.Workspace)\dropModule\Microsoft.VisualStudio.DSC\Microsoft.VisualStudio.DSC.psd1"
+
+          $prerelease = $manifest.PrivateData.PSData.Prerelease
+          $isPreRelease = -not [string]::IsNullOrEmpty($prerelease)
+
+          $publishVersion = $manifest.Version.ToString()
+          if ($isPreRelease) {
+              $publishVersion = "$publishVersion-$prerelease"
+          }
+
+          Write-Host "Module version to publish: $publishVersion (pre-release: $isPreRelease)"
           Write-Host "##vso[task.setvariable variable=isPublishPreRelease;]$isPreRelease"
-        displayName: 'Determining if module is Pre Release'
+          Write-Host "##vso[task.setvariable variable=publishVersion;]$publishVersion"
+        displayName: 'Determining module version and Pre Release state'
 
       - pwsh: |
-          $publishModuleParams = @{
-              Path = "$(Pipeline.Workspace)\dropModule\Microsoft.VisualStudio.DSC"
-              ApiKey = "$(VSSetup-Powershell-API-Key)"
-              Verbose = $true
-              Confirm = $false
+          $ErrorActionPreference = 'Stop'
+
+          Install-Module -Name Microsoft.PowerShell.PSResourceGet -RequiredVersion '$(PSResourceGetVersion)' -Repository PSGallery -Force
+
+          # Publish-PSResource reads the repository store while binding parameters, which throws on a
+          # fresh agent where the store has never been created. Touching it first creates the default.
+          # See https://github.com/PowerShell/PSResourceGet/issues/1806
+          Get-PSResourceRepository | Out-Null
+
+          # Gallery packages are immutable, so re-running this stage after the upload already landed
+          # fails the whole release with a 409. Only the OData entity endpoint reports this honestly -
+          # the /package/{id}/{version} route answers 200 for versions that don't exist.
+          $versionUri = "https://www.powershellgallery.com/api/v2/Packages(Id='Microsoft.VisualStudio.DSC',Version='$(publishVersion)')"
+          $existing = Invoke-WebRequest -Uri $versionUri -SkipHttpErrorCheck -ErrorAction SilentlyContinue
+
+          if ($existing.StatusCode -eq 200) {
+              Write-Host "##vso[task.logissue type=warning]$(publishVersion) is already on the PowerShell Gallery, skipping upload so the rest of the release can finish."
           }
- 
-          Install-Module -Name Microsoft.PowerShell.PSResourceGet -Repository PSGallery -Force
+          else {
+              $publishModuleParams = @{
+                  Path       = "$(Pipeline.Workspace)\dropModule\Microsoft.VisualStudio.DSC"
+                  Repository = 'PSGallery'
+                  ApiKey     = "$(VSSetup-Powershell-API-Key)"
+                  Verbose    = $true
+                  Confirm    = $false
+              }
 
-          Publish-PsResource @publishModuleParams
-
+              Publish-PSResource @publishModuleParams
+          }
         displayName: 'Upload module to PowerShell Gallery'
 
       - pwsh: |
-          iwr https://www.powershellgallery.com/api/v2/package/Microsoft.VisualStudio.DSC/$(Build.BuildNumber) -outfile $(Build.ArtifactStagingDirectory)\Microsoft.VisualStudio.DSC.$(Build.BuildNumber).nupkg
-          
+          $ErrorActionPreference = 'Stop'
+
+          $nupkgPath = "$(Build.ArtifactStagingDirectory)\Microsoft.VisualStudio.DSC.$(publishVersion).nupkg"
+
+          $download = Invoke-WebRequest `
+              -Uri "https://www.powershellgallery.com/api/v2/package/Microsoft.VisualStudio.DSC/$(publishVersion)" `
+              -OutFile $nupkgPath `
+              -PassThru
+
+          # That route redirects to the latest package when the requested version isn't on the CDN yet,
+          # so without this the GitHub release can end up carrying the previous version's nupkg.
+          $resolved = $download.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+          $expected = "microsoft.visualstudio.dsc.$(publishVersion).nupkg"
+
+          if (-not $resolved.EndsWith($expected, [System.StringComparison]::OrdinalIgnoreCase)) {
+              throw "Expected to download '$expected' but the gallery served '$resolved'."
+          }
         displayName: 'Downloading published nupkg to artifact staging'
 
       - task: GitHubRelease@1

--- a/build/publish.yml
+++ b/build/publish.yml
@@ -96,9 +96,15 @@ stages:
         inputs:
           gitHubConnection: 'GitHub-Preecington'
           repositoryName: 'Microsoft/VisualStudioDSC'
+          # 'edit' updates the release when the tag already has one and falls back to creating it
+          # when it doesn't. 'create' throws a 422 for a tag that has already been released, which
+          # would strand a re-run on the last step even once the Gallery steps are re-runnable.
+          action: edit
           target: '$(Build.SourceVersion)'
-          tagSource: userSpecifiedTag
           tag: '$(Build.BuildNumber)'
           assets: '$(Build.ArtifactStagingDirectory)\*.nupkg'
+          # Drop the existing assets before uploading so the release always carries the nupkg
+          # produced by the run that last touched it.
+          assetUploadMode: delete
           isPreRelease: $(isPublishPreRelease)
 

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -13,3 +13,8 @@ variables:
 
   - name: 'ModuleBuildFolder'
     value: '$(ModuleFolder)\build'
+
+  # Pinned so a bad PSGallery release can't take the pipeline down the way 1.1.1 did.
+  # See https://github.com/PowerShell/PSResourceGet/issues/1806
+  - name: 'PSResourceGetVersion'
+    value: '1.2.0'


### PR DESCRIPTION
## What?

Makes the publish stage re-runnable and pins PSResourceGet. Fixes AB#2507651.

## Why?

The PSResourceGet 1.1.1 regression (PowerShell/PSResourceGet#1806) fixed itself upstream in 1.2.0, and 1.0.32 reached the Gallery on 16 Jun. The release still didn't complete, and there's no way to retry: Gallery packages are immutable, so once the upload lands every re-run dies on a 409 (build 14392435). Version comes from nbgv git height, so you can't retry with a new version without pushing a commit first.

## How?

Version now comes from the module manifest into a `publishVersion` variable, instead of assuming `$(Build.BuildNumber)` matches it.

Upload skips with a warning if the version is already on the Gallery. The endpoint choice matters here:

| endpoint | real version | bogus version |
|---|---|---|
| `HEAD /package/{id}/{ver}` | 404 | 404 |
| `GET /package/{id}/{ver}` | 200 | **200** |
| `GET Packages(Id=,Version=)` | 200 | 404 |

Only the OData route is honest. The obvious one would have silently skipped every real publish.

Same quirk hits the download step, and that one's a live bug: the route redirects to latest when the version isn't on the CDN yet, so the GitHub release can end up carrying the previous version's nupkg. Now verified against the resolved URI.

PSResourceGet pinned to 1.2.0 in `variables.yml`. Kept the `Get-PSResourceRepository` warm-up in case we ever unpin.

## Testing

- [ ] Added unit tests (no harness for pipeline YAML)
- [X] Manually verified

Both files parse, inline scripts pass the AST parser. Exercised both guards against the live Gallery: 1.0.32 skips and downloads clean, 1.0.99 publishes and throws on the mismatched download. Can't verify end to end until the next main build.

## Additional information

The download bug wasn't the target. It fell out of testing the 409 guard.